### PR TITLE
Makefile: pass libraries in correct order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ tcpclient.o: tcpclient.c common.h utils.h
 udpclient.o: udpclient.c common.h utils.h
 
 tcpserver: tcpserver.o
-	$(CC) -levent -o $@ $<
+	$(CC) -o $@ $< -levent
 
 tcpclient: tcpclient.o poisson.o utils.o
-	$(CC) -levent -levent_openssl -lssl -lm -o $@ poisson.o utils.o $<
+	$(CC) -o $@ poisson.o utils.o $< -levent -levent_openssl -lssl -lm
 
 udpclient: udpclient.o
-	$(CC) -levent -lm -o $@ poisson.o utils.o $<
+	$(CC) -o $@ poisson.o utils.o $< -levent -lm
 
 clean:
 	rm -f *.o tcpserver tcpclient udpclient


### PR DESCRIPTION
The order of the libraries is significant and this ordering
is necessary for the compiler to find the symbols in libraries
on Ubuntu 18.04.